### PR TITLE
Update index.html and automate the process

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ To sign the rules, see HTTPS Everywhere docs [here](https://github.com/EFForg/ht
 
 For the production rules this signing must be done via the official signing ceremony and the existing SD release key (JWK formatted version of the pubkey is in `release-pubkey.jwk`). There is some internal documentation with more detailed instructions on this, ping `@redshiftzero` if you need to do this.
 
-Once you have the signature, place the files to serve in the root of the git tree in this repository,and then update the directory listing in `index.html`.
+Once you have the signature, place the files to serve in the root of the git tree in this repository, and then update the directory listing in `index.html` using the `update_index.sh` shell script in this directory.
 
-Commit the resulting `index.html` and all files to be served.
+Inspect the diff. If it looks good, commit the resulting `index.html` and all files to be served.
 
 Upon merge the ruleset release will be live.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <html>
-    <a href='rulesets-signature.1588004096.sha256'>rulesets-signature.1588004096.sha256</a><br>
+    <a href='rulesets-signature.1593528236.sha256'>rulesets-signature.1593528236.sha256</a><br>
     <a href='latest-rulesets-timestamp'>latest-rulesets-timestamp</a><br>
-    <a href='default.rulesets.1588004096.gz'>default.rulesets.1588004096.gz</a><br>
+    <a href='default.rulesets.1593528236.gz'>default.rulesets.1593528236.gz</a><br>
 </html>

--- a/update_index.sh
+++ b/update_index.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+TIMESTAMP="$(<latest-rulesets-timestamp)"
+
+# Replaces all occurrences of the form .0. with the new timestamp, where 0
+# is any sequence of numbers with at least one digit
+sed -Ei "s/\.[0-9]+\./\.$TIMESTAMP\./g" index.html
+
+echo "Timestamp in index.html has been set to $TIMESTAMP. Please inspect the"
+echo "diff below."
+echo
+git diff index.html


### PR DESCRIPTION
The `index.html` was not updated in #7, so https://securedrop.org/https-everywhere/ still links to the old version of the ruleset. This PR updates it, and also provides a little shell script to automate this step in future.

# Test plan
- [ ] Verify that the updated links in `index.html` resolve to valid files that are currently deployed on https://securedrop.org/https-everywhere/
- [ ] As a throwaway change, update the `latest-rulesets-timestamp` file with a random new timestamp, and attempt to update `index.html` using `./update_index.sh`.