### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+### Status
+
+Work in Progress / Ready for review
+
+### Review Checklist
+
+- [ ] Changes to `onboarded.txt` are accurate
+- [ ] The file `default.rulesets.TIMESTAMP.gz` has been updated, extracting that file and inspecting the contents of the JSON file produces the expected rules
+- [ ] The ruleset has been verified by modifying the httpseverywhere configuration in a Tor Browser instance pointin to `Path Prefix`: `https://raw.githubusercontent.com/freedomofpress/securedrop-https-everywhere-ruleset/$BRANCH_NAME`
+- [ ] `index.html` has been updated using `./update_index.sh`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,5 @@ Work in Progress / Ready for review
 
 - [ ] Changes to `onboarded.txt` are accurate
 - [ ] The file `default.rulesets.TIMESTAMP.gz` has been updated, extracting that file and inspecting the contents of the JSON file produces the expected rules
-- [ ] The ruleset has been verified by modifying the httpseverywhere configuration in a Tor Browser instance pointin to `Path Prefix`: `https://raw.githubusercontent.com/freedomofpress/securedrop-https-everywhere-ruleset/$BRANCH_NAME`
+- [ ] The ruleset has been verified by modifying the HTTPS Everywhere configuration in a Tor Browser instance pointing to `Path Prefix`: `https://raw.githubusercontent.com/freedomofpress/securedrop-https-everywhere-ruleset/$BRANCH_NAME`
 - [ ] `index.html` has been updated using `./update_index.sh`


### PR DESCRIPTION
Adds a review checklist to reduce the likelihood of omissions when reviewing/merging rulesets, as merging to the main branch will automatically deploy these rules (example [1] )

### Suggested test plan: 
- [ ] Does the suggested PR template / test plan make sense?


[1] https://github.com/freedomofpress/securedrop-https-everywhere-ruleset/pull/8