### PR TITLE
Add nginx container to serve ruleset files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ serve: ## Builds Nginx container to serve generated files
 	@echo "=============================================================================="
 	@echo "          Serving ruleset at http://localhost:4080/https-everywhere/          "
 	@echo "=============================================================================="
-	@docker run --rm -p 4080 "$(image)"
+	@docker run --rm -p 127.0.0.1:4080:4080 "$(image)"
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
+timestamp := $(shell cat latest-rulesets-timestamp)
+image := fpf.local/securedrop-https-everywhere-ruleset:$(timestamp)
+
 .PHONY: test-key
 test-key: ## Generates a test key for development/testing purposes locally.
 	openssl genrsa -out key.pem 4096
 	openssl rsa -in key.pem -outform PEM -pubout -out public.pem
 	python jwk.py > test-key.jwk
+
+.PHONY: serve
+serve: ## Builds Nginx container to serve generated files
+	@docker build --build-arg "timestamp=$(timestamp)" -t "$(image)" -f docker/Dockerfile .
+	@echo "=============================================================================="
+	@echo "          Serving ruleset at http://localhost:4080/https-everywhere/          "
+	@echo "=============================================================================="
+	@docker run --rm -p 4080 "$(image)"
 
 .PHONY: help
 help:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ For the production rules this signing must be done via the official signing cere
 
 Once you have the signature, place the files to serve in the root of the git tree in this repository, and then update the directory listing in `index.html` using the `update_index.sh` shell script in this directory.
 
-Inspect the diff. If it looks good, commit the resulting `index.html` and all files to be served.
+# Verifying
 
-Upon merge the ruleset release will be live.
+Inspect the diff. If it looks good, commit the resulting `index.html` and all files to be served. To test locally, run
+
+    make serve
+
+And configure your browser to use `http://localhost:4080/https-everywhere/`.
+
+# Deployment
+
+Upon merge the container will be published to `quay.io/freedomofpress` and the new tag will be deployed automatically.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+# sha256 as of 2020-09-25 for mainline-alpine
+FROM nginx@sha256:4635b632d2aaf8c37c8a1cf76a1f96d11b899f74caa2c6946ea56d0a5af02c0c
+ARG timestamp
+
+COPY docker/nginx.conf /etc/nginx
+RUN mkdir -p /opt/nginx && chown nginx:nginx /opt/nginx
+
+USER nginx
+RUN mkdir -p /opt/nginx/run /opt/nginx/root/https-everywhere
+COPY index.html latest-rulesets-timestamp default.rulesets.${timestamp}.gz rulesets-signature.${timestamp}.sha256 /opt/nginx/root/https-everywhere

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,4 +7,4 @@ RUN mkdir -p /opt/nginx && chown nginx:nginx /opt/nginx
 
 USER nginx
 RUN mkdir -p /opt/nginx/run /opt/nginx/root/https-everywhere
-COPY index.html latest-rulesets-timestamp default.rulesets.${timestamp}.gz rulesets-signature.${timestamp}.sha256 /opt/nginx/root/https-everywhere
+COPY index.html latest-rulesets-timestamp default.rulesets.${timestamp}.gz rulesets-signature.${timestamp}.sha256 /opt/nginx/root/https-everywhere/

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,7 +20,7 @@ http {
         location / {
             root /opt/nginx/root;
             index index.html;
+            rewrite ^/https-everywhere$ $uri/;
         }
     }
 }
-

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,26 @@
+pid /opt/nginx/run/nginx.pid;
+
+events {
+}
+
+http {
+    include /etc/nginx/mime.types;
+    sendfile on;
+
+    server {
+        listen 4080;
+        port_in_redirect off;
+
+        client_body_temp_path /opt/nginx/run/client_temp;
+        proxy_temp_path /opt/nginx/run/proxy_temp_path;
+        fastcgi_temp_path /opt/nginx/run/fastcgi_temp;
+        uwsgi_temp_path /opt/nginx/run/uwsgi_temp;
+        scgi_temp_path /opt/nginx/run/scgi_temp;
+
+        location / {
+            root /opt/nginx/root;
+            index index.html;
+        }
+    }
+}
+


### PR DESCRIPTION
This adds a very basic container image definition to serve the ruleset files with Nginx. They're served on `/https-everywhere/`; `/` will return a 403.

I chose a port arbitrarily; this is intended to be deployed behind a routing layer of some sort (e.g. k8s ingress) that only forwards requests matching a path to this backend.

### Status

Ready for review

### Review Checklist

- No changes to `onboarded.txt`
- No changes to `default.rulesets.TIMESTAMP.gz` -- inspecting the contents of the JSON file produces the expected rules
- [x] The ruleset has been verified by modifying the HTTPS Everywhere configuration in a Tor Browser instance pointing to `Path Prefix`: `https://raw.githubusercontent.com/freedomofpress/securedrop-https-everywhere-ruleset/$BRANCH_NAME` -- I added the HTTPS Everywhere extension to Tor Browser, updated the Path Prefix for the existing entry, visited a site in the ruleset, nothing seems obviously broken.
- Running `./update_index.sh` produces no changes, as expected
