### PR TITLE
Remove 'timestamp' argument, include all rulesets in repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-timestamp := $(shell cat latest-rulesets-timestamp)
-image := fpf.local/securedrop-https-everywhere-ruleset:$(timestamp)
+image := fpf.local/securedrop-https-everywhere-ruleset:$(shell cat latest-rulesets-timestamp)
 
 .PHONY: test-key
 test-key: ## Generates a test key for development/testing purposes locally.
@@ -9,7 +8,7 @@ test-key: ## Generates a test key for development/testing purposes locally.
 
 .PHONY: serve
 serve: ## Builds Nginx container to serve generated files
-	@docker build --build-arg "timestamp=$(timestamp)" -t "$(image)" -f docker/Dockerfile .
+	@docker build -t "$(image)" -f docker/Dockerfile .
 	@echo "=============================================================================="
 	@echo "          Serving ruleset at http://localhost:4080/https-everywhere/          "
 	@echo "=============================================================================="

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,14 @@
 # sha256 as of 2020-09-25 for mainline-alpine
 FROM nginx@sha256:4635b632d2aaf8c37c8a1cf76a1f96d11b899f74caa2c6946ea56d0a5af02c0c
-ARG timestamp
 
 COPY docker/nginx.conf /etc/nginx
 RUN mkdir -p /opt/nginx && chown nginx:nginx /opt/nginx
 
 USER nginx
 RUN mkdir -p /opt/nginx/run /opt/nginx/root/https-everywhere
-COPY index.html latest-rulesets-timestamp default.rulesets.${timestamp}.gz rulesets-signature.${timestamp}.sha256 /opt/nginx/root/https-everywhere/
+
+# Only the latest rulesets are required (and listed in index.html), but
+# include all versions that exist in the repo in case a client requests
+# an old one (maybe they failed to fetch the latest timestamp).
+
+COPY index.html latest-rulesets-timestamp default.rulesets.*.gz rulesets-signature.*.sha256 /opt/nginx/root/https-everywhere/


### PR DESCRIPTION
### Status

Ready for review

In the initial version of this container we specifically only included the rulesets files with a specified timestamp (in CI this was read out of `latest-rulesets-timestamp`). This isn't necessary, and is actually a change from the current git-based deployment which checks out the entire repo.

I don't think it's likely that a client would request an old file (maybe it failed to fetch the timestamp), but it's probably safest to keep the existing behavior in case it does and would fail open on a 404.

If we don't pass in an arg that depends on the repo content, it would simplify our build logic and enable some deduplication of CI config between various containers.

### Review Checklist

- No changes to `onboarded.txt`
- No changes to `default.rulesets.TIMESTAMP.gz`
- [x] The ruleset has been verified by modifying the HTTPS Everywhere configuration in a Tor Browser instance
- No changes to `index.html`

Additional check: `curl -I https://securedrop.org/https-everywhere/default.rulesets.1588004096.gz` returns a 200, so `make serve` should show the same result from `localhost:4080`.