### PR TITLE
Add more-sensible content types for non-text files

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -21,6 +21,12 @@ http {
             root /opt/nginx/root;
             index index.html;
             rewrite ^/https-everywhere$ $uri/;
+
+            types {
+              text/html html;
+              application/gzip gz;
+              application/octet-stream sha256;
+            }
         }
     }
 }


### PR DESCRIPTION
This is not an urgent change, but in case someone needs to look at the ruleset endpoint to debug something, we should have better Content-Types. The old setup changed the default to `application/octet-stream` for all files; while the browser side of things doesn't care about the type, it does feel like a regression. This improves things somewhat by setting a correct GZip type for the .gz file and leaving the plain-text timestamp as text.

### Status

Ready for review

Additional verification steps:

- [ ] Run `make serve`, load up the local page it prints, observe that clicking on links gives friendlier results (download the gzip file, see the timestamp in browser)

### Review Checklist

- No hanges to `onboarded.txt` are accurate
- [x] The file `default.rulesets.TIMESTAMP.gz` has been updated, extracting that file and inspecting the contents of the JSON file produces the expected rules
- [x] The ruleset has been verified by modifying the HTTPS Everywhere configuration in a Tor Browser instance pointing to `Path Prefix`: `https://raw.githubusercontent.com/freedomofpress/securedrop-https-everywhere-ruleset/$BRANCH_NAME`
- N/A: `index.html` update