### PR TITLE
application/octet-stream, Don't rewrite, just redirect

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,13 +20,7 @@ http {
         location / {
             root /opt/nginx/root;
             index index.html;
-            rewrite ^/https-everywhere$ $uri/;
-
-            types {
-              text/html html;
-              application/gzip gz;
-              application/octet-stream sha256;
-            }
+            default_type application/octet-stream;
         }
     }
 }


### PR DESCRIPTION
### Status

Ready for review

This supersedes https://github.com/freedomofpress/securedrop-https-everywhere-ruleset/pulls/15 for now, in order to  match the droplet nginx configuration:

- `application/octet-stream` for all files (except the index, still `text/html`)
- redirect with 301 to add a trailing slash. This default was previously removed based on review due to differences between running a local container and the deployment being behind a frontend nginx, but should be kept for now.

### Review Checklist

Same as https://github.com/freedomofpress/securedrop-https-everywhere-ruleset/pulls/15.