### PR TITLE
Add post-deployment task: directory update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,7 @@ Work in Progress / Ready for review
 - [ ] The file `default.rulesets.TIMESTAMP.gz` has been updated, extracting that file and inspecting the contents of the JSON file produces the expected rules
 - [ ] The ruleset has been verified by modifying the HTTPS Everywhere configuration in a Tor Browser instance pointing to `Path Prefix`: `https://raw.githubusercontent.com/freedomofpress/securedrop-https-everywhere-ruleset/$BRANCH_NAME`
 - [ ] `index.html` has been updated using `./update_index.sh`
+
+### Post-Deployment Checklist
+
+- [ ] Added/modified onion names have been updated in the SecureDrop Directory


### PR DESCRIPTION
### Status

Ready for review

### Description

The directory supports adding onion names alongside the v3 .onion address (example: https://securedrop.org/directory/barton-gellman/). We should make sure that those are added/updated until that's automated, so let's add it to the checklist for now.