### PR TITLE
Add basic CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2.1
+
+jobs:
+  verify:
+    docker:
+      - image: cimg/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Verify ruleset signature
+          command: |
+            make verify
+
+workflows:
+  verify:
+    jobs:
+      - verify

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ serve: ## Builds Nginx container to serve generated files
 	@echo "=============================================================================="
 	@docker run --rm -p 127.0.0.1:4080:4080 "$(image)"
 
+.PHONY: verify
+verify: ## Verifies the signature of the latest ruleset. Requires openssl to be installed.
+	@echo "Attempting to verify ruleset signature using openssl."
+	@./scripts/verify
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/scripts/verify
+++ b/scripts/verify
@@ -3,14 +3,14 @@ set -e
 set -u
 set -o pipefail
 
-LATEST_TIMESTAMP=$(cat latest-rulesets-timestamp)
-LATEST_RULESET=default.rulesets.${LATEST_TIMESTAMP}.gz
+LATEST_TIMESTAMP="$(cat latest-rulesets-timestamp)"
+LATEST_RULESET="default.rulesets.${LATEST_TIMESTAMP}.gz"
 
 if  [ ! -f "${LATEST_RULESET}" ]; then
   echo "Ruleset file '${LATEST_RULESET}' matching latest timestamp '${LATEST_TIMESTAMP}' not found."
   exit 1
 fi
 
-openssl dgst -signature rulesets-signature.${LATEST_TIMESTAMP}.sha256 \
+openssl dgst -signature "rulesets-signature.${LATEST_TIMESTAMP}.sha256" \
   -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:32 -verify public_release.pem \
-  ${LATEST_RULESET}
+  "${LATEST_RULESET}"

--- a/scripts/verify
+++ b/scripts/verify
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+
+LATEST_TIMESTAMP=$(cat latest-rulesets-timestamp)
+LATEST_RULESET=default.rulesets.${LATEST_TIMESTAMP}.gz
+
+if  [ ! -f "${LATEST_RULESET}" ]; then
+  echo "Ruleset file '${LATEST_RULESET}' matching latest timestamp '${LATEST_TIMESTAMP}' not found."
+  exit 1
+fi
+
+openssl dgst -signature rulesets-signature.${LATEST_TIMESTAMP}.sha256 \
+  -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:32 -verify public_release.pem \
+  ${LATEST_RULESET}


### PR DESCRIPTION
Checks that we have a ruleset matching the latest timestamp and, if so, verifies its signature using `openssl`

Towards #21 but does not yet add any content validation.

## Test plan
- Visual review
- Run `make verify` locally
- [ ] Observe exit code zero (`echo $?`) and "Verified OK" output
- Replace signature file temporarily with an invalid one
- Run `make verify`
- [ ] Observe nonzero exit code and verification error
- Temporarily remove `defaults.rulesets` file for latest timestamp
- Run `make verify`
- [ ] Observe nonzero exit code and "file not found" error

### Status

Ready for initial review. 