### PR TITLE
Deal with // in URLs

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -17,9 +17,12 @@ http {
         uwsgi_temp_path /opt/nginx/run/uwsgi_temp;
         scgi_temp_path /opt/nginx/run/scgi_temp;
 
+        merge_slashes off;
+
         location / {
             root /opt/nginx/root;
             index index.html;
+            rewrite ^/https-everywhere($|//+)(.*) /https-everywhere/$2 permanent;
         }
     }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -20,7 +20,6 @@ http {
         location / {
             root /opt/nginx/root;
             index index.html;
-            default_type application/octet-stream;
         }
     }
 }


### PR DESCRIPTION
### Status

Closes https://github.com/freedomofpress/infrastructure/issues/3425

We are getting requests that include `/https-everywhere//`. The default behavior of nginx is to merge multiple slashes and serve the page anyway. Because we want to purge Cloudflare by individual URL, this is undesirable. Instead, redirect anything without exactly 1 slash to the canonical `/https-everywhere/`.

This also includes removal of the `application/octet-stream` MIME type, which has been tested in the `https-everywhere-2021` branch's container for a while with no ill effects.

### Review Checklist

No changes to ruleset itself or not-included-in-the-container files.

Locally, run `make serve` and check http://127.0.0.1:4080/ .

This should be checked thoroughly on staging before merge-and-deploy-to-prod. To do so I will:

- Build and push container image manually
- Update k8s image tag for staging only and PR there

### Post-Deployment Checklist

Verify redirect behavior again with both `curl` and the extension. Unfortunately I don't think it's possible to verify that Cloudflare purging happens if the ruleset itself has no changes.
