### PR TITLE
Account for external 2021 path in the nginx redirect

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -22,7 +22,9 @@ http {
         location / {
             root /opt/nginx/root;
             index index.html;
-            rewrite ^/https-everywhere($|//+)(.*) /https-everywhere/$2 permanent;
+            # This line has been adjusted for the temporary different external URL.
+            # Don't include this change in the main branch.
+            rewrite ^/https-everywhere($|//+)(.*) /https-everywhere-2021/$2 permanent;
         }
     }
 }


### PR DESCRIPTION
### Status

With the changes in #59 to handle `//`, it doesn't really make sense to try to handle trailing slash redirects over in ingress-nginx. Let's have the internal static-file nginx be responsible, and configure it to know its external URL.

This is all kind of a mess because we're translating `/https-everywhere-2021` on the outside to `/https-everywhere` in here. I'm putting this right into the nginx.conf on the assumption that this URL is temporary and we will get rid of it pretty soon. But if we should add some sort of runtime configuration, I can look into that.

### Review Checklist

N/A - Visual review and see next section

### Post-Deployment Checklist

A curl of `http://staging.securedrop.org/https-everywhere-2021` should return `location: http://staging.securedrop.org/https-everywhere-2021/`.