### PR TITLE
Add exemptions to resolve `sddir.py` breakage

### DIFF
--- a/sddir.py
+++ b/sddir.py
@@ -1,10 +1,15 @@
+import csv
+import logging
+import os
 import re
 import requests
-import os
-import csv
 import urllib
 
 from typing import Dict
+
+# Configure logging output
+logfmt = "%(asctime)s %(levelname)-8s %(message)s"
+logging.basicConfig(format=logfmt, level=logging.DEBUG, datefmt="%Y-%m-%d %H:%M:%S")
 
 SECUREDROP_ONION_PSEUDO_TLD = ".securedrop.tor.onion"
 DEFAULT_ONION_PROTOCOL = "http://"  # We don't store protocol in the directory
@@ -48,8 +53,8 @@ def write_custom_ruleset(onboarded_org: str, sd_rewrite_rule: str, directory_ent
     try:
         directory_entry = directory_entries[onboarded_org]
     except KeyError:
-        print(f"Failed to find '{onboarded_org}', org names are:")
-        print(directory_entries.keys())
+        logging.error(f"Failed to find '{onboarded_org}', org names are:")
+        logging.error(directory_entries.keys())
         raise
 
     ruleset = """<ruleset name="{org_name}">\n\t<target host="{securedrop_redirect_url}" />\n\t<rule from="^http[s]?://{securedrop_redirect_url}"
@@ -76,7 +81,8 @@ if __name__ == "__main__":
         directory_entries = get_securedrop_directory()
         for row in reader:
             if row["primary_domain"] in EXEMPTIONS:
+                logging.warning(f"Skipping exempted domain: {row['primary_domain']}")
                 continue
             write_custom_ruleset(row["primary_domain"], row["sd_rewrite_rule"], directory_entries)
 
-    print("✔️ Custom rulesets written to directory: ./{}".format(RULESET_DIR))
+    logging.info("✔️ Custom rulesets written to directory: ./{}".format(RULESET_DIR))

--- a/sddir.py
+++ b/sddir.py
@@ -4,7 +4,7 @@ import os
 import csv
 import urllib
 
-from typing import Dict, List
+from typing import Dict
 
 SECUREDROP_ONION_PSEUDO_TLD = ".securedrop.tor.onion"
 DEFAULT_ONION_PROTOCOL = "http://"  # We don't store protocol in the directory
@@ -13,8 +13,9 @@ RULESET_DIR = "rulesets"
 
 EXEMPTIONS = ["tcfmailvault.info"]
 
+
 def remove_umlaut(text: str) -> str:
-    text = re.sub('ü', 'u', text)
+    text = re.sub("ü", "u", text)
     return text
 
 
@@ -30,7 +31,7 @@ def get_securedrop_directory() -> Dict:
         ).netloc
         # For redirect URL, drop TLD from base_url: newsorg.com -> newsorg.securedrop.tor.onion
         directory_entry["securedrop_redirect_url"] = (
-            directory_entry["base_url"].rsplit('.',1)[0] + SECUREDROP_ONION_PSEUDO_TLD
+            directory_entry["base_url"].rsplit(".", 1)[0] + SECUREDROP_ONION_PSEUDO_TLD
         )
         directory_entry["onion_addr_with_protocol"] = (
             DEFAULT_ONION_PROTOCOL + directory_entry["onion_address"]
@@ -56,7 +57,6 @@ def write_custom_ruleset(onboarded_org: str, sd_rewrite_rule: str, directory_ent
         org_name=directory_entry["title"],
         securedrop_redirect_url=sd_rewrite_rule,
         onion_addr_with_protocol=directory_entry["onion_addr_with_protocol"],
-        securedrop_tld=SECUREDROP_ONION_PSEUDO_TLD,
     )
 
     RULESET_OUTPUT = "securedrop-ruleset.xml"
@@ -71,14 +71,12 @@ if __name__ == "__main__":
     # We don't want to generate rules for all organizations. Instead we want to
     # do so on an opt-in basis. The following text file contains the homepages
     # of the organizations that have opted in.
-    with open('onboarded.txt', 'r') as f:
+    with open("onboarded.txt", "r") as f:
         reader = csv.DictReader(f)
         directory_entries = get_securedrop_directory()
         for row in reader:
-            #write_custom_ruleset(org.strip(), directory_entries)
             if row["primary_domain"] in EXEMPTIONS:
                 continue
             write_custom_ruleset(row["primary_domain"], row["sd_rewrite_rule"], directory_entries)
-
 
     print("✔️ Custom rulesets written to directory: ./{}".format(RULESET_DIR))

--- a/sddir.py
+++ b/sddir.py
@@ -10,8 +10,8 @@ SECUREDROP_ONION_PSEUDO_TLD = ".securedrop.tor.onion"
 DEFAULT_ONION_PROTOCOL = "http://"  # We don't store protocol in the directory
 RULESET_DIR = "rulesets"
 
-
-EXEMPTIONS = ["tcfmailvault.info"]
+# tcfmailvault.info = unlisted SecureDrop; all others: extended outage
+EXEMPTIONS = ["tcfmailvault.info", "espenandersen.no", "www.forbes.com", "www.sfchronicle.com"]
 
 
 def remove_umlaut(text: str) -> str:


### PR DESCRIPTION
### Status

Ready for review

Resolves #69

### Description

- We already have a mechanism for exempting sites from directory lookup, so let's use that for sites with extended outages. As far as I can tell, the existing rulesets for those sites will be preserved (we should of course remove those if the outages continue much longer), but it would be great for the reviewer to step through the full generation process to confirm that.
- The code was failing a bunch of flake8 checks; I fixed most of those and applied black code formatting rules. It's a separate commit for ease of review.

### Review Checklist

- [ ] Verify that you can follow the ruleset generation process, and that exempted sites are preserved.