### PR TITLE
Enable dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "all"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Status

Ready for review

### Review Checklist

- [ ] Visual review; same as https://github.com/freedomofpress/securedrop-docs/pull/536


