### PR TITLE
Make it easier to copy the hash by adding spaces

### DIFF
--- a/upstream/async-request.sh
+++ b/upstream/async-request.sh
@@ -18,8 +18,8 @@ TIMESTAMP=`date +%s`
 REFERENCE=`git rev-parse HEAD`
 echo "{ \"timestamp\": $TIMESTAMP, \"reference\": \"$REFERENCE\", \"rulesets\":" "`cat $RULESETS_FILE`" "}" | tr -d '\n' | gzip -nc > $2/default.rulesets.$TIMESTAMP.gz
 
-echo 'Hash for signing: '
-sha256sum $2/default.rulesets.$TIMESTAMP.gz | cut -f1 -d' '
+echo 'Hash for signing (do not include spaces): '
+sha256sum $2/default.rulesets.$TIMESTAMP.gz | cut -f1 -d' ' | sed 's/.\{4\}/& /g'
 echo metahash for confirmation only $(sha256sum $2/default.rulesets.$TIMESTAMP.gz | cut -f1 -d' ' | tr -d '\n' | sha256sum | cut -c1-6) ...
 
 echo 'Paste in the data from the QR code, then type Ctrl-D:'


### PR DESCRIPTION
### Status

Ready for review

### Description

Make it easier to copy the hash by adding spaces. Specific solution used here was suggested by Claude: https://gist.github.com/legoktm/fd6613dba7e841b18a6c28d5c2d22260

### Test plan

* [ ] Run `sha256sum default.rulesets.1742482399.gz | cut -f1 -d' '` (current code)
* [ ] Now run `sha256sum default.rulesets.1742482399.gz | cut -f1 -d' ' | sed 's/.\{4\}/& /g'`, verify that the hash is the same as above, but with spaces.