### PR TITLE
Add notify job to update k8s manifests on image rebuild

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,3 +23,19 @@ jobs:
       add-branch-tags: true
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  notify:
+    uses: freedomofpress/actionslib/.github/workflows/update-k8s-trigger.yaml@main
+    needs:
+    - build
+    if: ${{ needs.build.result == 'success' }}
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    with:
+      trigger: https-everywhere/${{ github.ref_name }}
+      sha: ${{ github.sha }}
+    secrets:
+      local-token: ${{ secrets.GITHUB_TOKEN }}
+      k8s-configs-token: ${{ secrets.K8S_CONFIGS_GITHUB_TOKEN }}


### PR DESCRIPTION
### Status

Ready for review

### Review Checklist

- [x] Changes to `onboarded.txt` are accurate
- [x] The file `default.rulesets.TIMESTAMP.gz` has been updated, extracting that file and inspecting the contents of the JSON file produces the expected rules
- [x] The ruleset has been verified by modifying the HTTPS Everywhere configuration in a Tor Browser instance pointing to `Path Prefix`: `https://raw.githubusercontent.com/freedomofpress/securedrop-https-everywhere-ruleset/$BRANCH_NAME`
- [x] `index.html` has been updated using `./update_index.sh`

### Post-Deployment Checklist

- [ ] Added/modified onion names have been updated in the SecureDrop Directory
